### PR TITLE
return tag of the new version

### DIFF
--- a/application.py
+++ b/application.py
@@ -7,12 +7,13 @@ application = Flask(__name__)
 @application.route('/core-wallet/checkversion')
 def check_version():
 	version = request.args.get('version')
-	current = '6.2.0.72'
+	current = '6.2.1.30'
 	changed = (version==current)
 	return jsonify(
-		latest=True,
+		latest=changed,
 		current_version=current,
-		change_log='Initial version'
+		change_log='Initial version',
+		tag = 'v6.2.1'
 	)
 
 # run the app.


### PR DESCRIPTION
Server should return the tag of the new version, so the client can link directly to the download page of the release